### PR TITLE
wbdev: add docker4mac support

### DIFF
--- a/wbdev
+++ b/wbdev
@@ -30,7 +30,15 @@ jessie-armel|jessie-armhf)
 esac
 
 IMAGE=${WBDEV_IMAGE:-contactless/devenv}
-PREFIX="$HOME/wbdev/go/src/github.com/contactless"
+
+if [[ $OSTYPE == darwin* ]]
+then
+	VM_HOME="/home/$USER"
+else
+	VM_HOME=$HOME
+fi
+
+PREFIX="$VM_HOME/wbdev/go/src/github.com/contactless"
 
 INSTALL_DEPS=${WBDEV_INSTALL_DEPS:-no}
 
@@ -42,7 +50,7 @@ docker run $DOCKER_TTY_OPTS --privileged --rm \
        -e ROOTFS_DIR="$ROOTFS_DIR" \
        -e TARGET_ARCH="$TARGET_ARCH" \
        -e INSTALL_DEPS="$INSTALL_DEPS" \
-       -v $HOME:$HOME \
+       -v $HOME:$VM_HOME \
        -v ${PWD%/*}:$PREFIX \
        $ssh_opts \
        -h wbdevenv \


### PR DESCRIPTION
Домашние папки на macOS находятся в /Users, а не в /home, из-за этого происходила ошибка при запуске, например, `wbdev chroot`:
```
wbdev chroot
Warning: WBDEV_TARGET is not set, defaulting to armel
proot warning: can't chdir("/Users/virus/wbdev/go/src/github.com/contactless/wb-mqtt-serial/./.") in the guest rootfs: No such file or directory
proot info: default working directory is now "/"
bash: cd: /Users/virus/wbdev/go/src/github.com/contactless/wb-mqtt-serial: No such file or directory
```

После этого коммита для macOS в контейнере домашняя директория будет браться не из стандартного `$HOME`, а генерироваться на основе имени пользователя.

Работоспособность на macOS проверил запуском `wbdev chroot` и `wbdev make` на wb-mqtt-serial. Под линуксом — не проверял.