### PR TITLE
Feature/board packages

### DIFF
--- a/boards/include/soc_imx23.sh
+++ b/boards/include/soc_imx23.sh
@@ -2,3 +2,5 @@ export ARCH=armel
 export KERNEL_FLAVOUR=wb2
 export IMAGE_TYPE=mx23
 export U_BOOT=UNSUPPORTED
+
+BOARD_PACKAGES+=( wb-adc-tools-mxs )

--- a/boards/include/soc_imx28.sh
+++ b/boards/include/soc_imx28.sh
@@ -2,3 +2,5 @@ export ARCH=armel
 export KERNEL_FLAVOUR=wb2
 export IMAGE_TYPE=mx28
 export U_BOOT=contrib/u-boot/u-boot.wb5.sd
+
+BOARD_PACKAGES+=( wb-adc-tools-mxs )

--- a/boards/init_board.sh
+++ b/boards/init_board.sh
@@ -7,6 +7,8 @@ board_include() {
 	source "$BOARDS_DIR/include/$1"
 }
 
+export BOARD_PACKAGES=()
+
 [[ -e "${BOARDS_DIR}/${BOARD}.sh" ]] && . "${BOARDS_DIR}/${BOARD}.sh" || {
 	echo "Unknown board $BOARD"
 	echo "Please specify one of:"

--- a/rootfs/create_rootfs.sh
+++ b/rootfs/create_rootfs.sh
@@ -229,6 +229,8 @@ install_wb5_packages() {
     wb-test-suite wb-mqtt-lirc lirc-scripts wb-hwconf-manager wb-mqtt-dac
 }
 
+[[ "${#BOARD_PACKAGES}" -gt 0 ]] && chr_apt "${BOARD_PACKAGES[@]}"
+
 board_install
 
 chr /etc/init.d/mosquitto stop


### PR DESCRIPTION
Добавляет возможность перечислять пакеты в board-файлах. Сейчас это нужно для того, чтоб ставить wb-adc-tools-mxs на mx23/28 борды (прописывается в soc_*.sh которые инклюдятся бордами).
Также это можно будет использовать чтоб организовать composable группы пакетов для разных задач, и в board-спеках собирать полный список пакетов который ставится в образ из частей, а не копипастой.