### PR TITLE
devenv: replace u-boot-tools with u-boot-tools-wb

### DIFF
--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -26,7 +26,7 @@ RUN apt update && apt install -y curl wget gnupg && \
        python3-smbus python3-setuptools liblog4cpp5-dev libpng-dev bison flex kmod dh-python \
        clang-format-15 clang-tidy-15 lintian ccache \
     # for image building \
-    fdisk u-boot-tools fit-aligner cpio \
+    fdisk u-boot-tools-wb fit-aligner cpio \
     # legacy requirement for kernel building \
     rsync \
     # for Jenkins deployments \

--- a/image/create_update.sh
+++ b/image/create_update.sh
@@ -52,7 +52,7 @@ include() {
 			$extra
 			compression = "none";
 
-			hash-1 {
+			hash@1 {
 				algo = "sha1";
 			};
 		};


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Revert #257, вместо этого используем mkimage из u-boot-tools-wb

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
TBD после https://github.com/wirenboard/u-boot-private/pull/73

