### PR TITLE
devenv: remove cross from default DEB_BUILD_PROFILES

### DIFF
--- a/devenv/wbdev_second_half.sh
+++ b/devenv/wbdev_second_half.sh
@@ -2,7 +2,7 @@
 # This file will be executed on host to run docker container
 
 export DEB_BUILD_OPTIONS=${DEB_BUILD_OPTIONS:-}
-export DEB_BUILD_PROFILES=${DEB_BUILD_PROFILES:-"cross"}
+export DEB_BUILD_PROFILES=${DEB_BUILD_PROFILES:-}
 DOCKER=${DOCKER:-"docker"}
 DOCKER_TTY_OPTS=-i
 if [ -t 0 ]; then


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Сейчас при сборке с `DEB_BUILD_PROFILES= wbdev cdeb` все равно DEB_BUILD_PROFILES по дефолту выставляется в cross. С этим проблема на трикси, где cross профиль не должен быть задан для не-кросс сборок. Там где cross профиль реально нужен, он выставляется в пайплайнах.

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
ci

