### PR TITLE
devenv: remove rootfs tarball

### DIFF
--- a/devenv/build.sh
+++ b/devenv/build.sh
@@ -10,7 +10,7 @@ do_build() {
 
 	time DEBIAN_RELEASE=$RELEASE ARCH=$ARCH WB_RELEASE=$WB_RELEASE WB_COPY_QEMU=true /root/rootfs/create_rootfs.sh $BOARD $ADDITIONAL_REPOS
 
-	rm -f /root/output/rootfs_base_${ARCH}.tar.gz
+	rm -f /root/output/rootfs_base_${WB_RELEASE}_${PLATFORM}*.tar.gz
 	/root/prep.sh
 }
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
тарболы с рутфс не удалялись из-за неверного имени, в результате devenv образ на 559M раздувается:
```sh
$ ls -lah /root/output
total 559M
drwxr-xr-x 2 root root 4.0K Apr 14 12:34 .
drwx------ 1 root root 4.0K Apr 14 12:17 ..
-rw-r--r-- 1 root root 274M Apr 14 12:22 rootfs_base_stable_wb6_bullseye_bullseye_r61c6d170.tar.gz
-rw-r--r-- 1 root root 285M Apr 14 12:35 rootfs_base_stable_wb8_bullseye_bullseye_re8f2a10a.tar.gz
```

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
локально

