### PR TITLE
devenv: use nexus proxy

### DIFF
--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -1,4 +1,5 @@
 FROM debian:bullseye
+ARG PYPI_REGISTRY_URL="https://nexus.hq.wirenboard.com/repository/pypi-group/simple/"
 LABEL org.opencontainers.image.authors="info@wirenboard.com"
 LABEL org.opencontainers.image.vendor="Wiren Board team"
 
@@ -37,7 +38,7 @@ RUN sed -i 's#deb.debian.org#mirror.docker.ru#' /etc/apt/sources.list && \
     # to install fpm later for simple package building \
     ruby-rubygems && gem install fpm && \
     # for clang-tidy checks
-    pip3 install compiledb && \
+    pip3 install compiledb -i ${PYPI_REGISTRY_URL} && \
     # set as defauls
     update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-15 100 && \
     update-alternatives --install /usr/bin/clang-tidy clang-tidy /usr/bin/clang-tidy-15 100


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
используем наше pypi прокси:
```sh
Looking in indexes: https://nexus.hq.wirenboard.com/repository/pypi-group/simple/
Collecting compiledb
  Downloading https://nexus.hq.wirenboard.com/repository/pypi-group/packages/compiledb/0.10.7/compiledb-0.10.7-py3-none-any.whl (26 kB)
Collecting bashlex
  Downloading https://nexus.hq.wirenboard.com/repository/pypi-group/packages/bashlex/0.18/bashlex-0.18-py2.py3-none-any.whl (69 kB)
Collecting click
  Downloading https://nexus.hq.wirenboard.com/repository/pypi-group/packages/click/8.1.8/click-8.1.8-py3-none-any.whl (98 kB)
Installing collected packages: click, bashlex, compiledb
Successfully installed bashlex-0.18 click-8.1.8 compiledb-0.10.7
```
___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


