### PR TITLE
Set QEMU_CPU=cortex-a53 for arm64

### DIFF
--- a/devenv/build.sh
+++ b/devenv/build.sh
@@ -7,6 +7,9 @@ source /root/common-deps.sh
 do_build() {
 	export RELEASE=$1 ARCH=$2 BOARD=$3 PLATFORM=$4 WB_RELEASE=${5:-stable} ADDITIONAL_REPOS=${*:6}
 	export ROOTFS="/rootfs/$RELEASE-$ARCH"
+	if [[ "$ARCH" = "arm64" ]]; then
+		export QEMU_CPU="cortex-a53"
+	fi
 
 	time DEBIAN_RELEASE=$RELEASE ARCH=$ARCH WB_RELEASE=$WB_RELEASE WB_COPY_QEMU=true /root/rootfs/create_rootfs.sh $BOARD $ADDITIONAL_REPOS
 

--- a/devenv/entrypoint.sh
+++ b/devenv/entrypoint.sh
@@ -66,6 +66,7 @@ trixie-arm64|current-arm64|wb8)
     WBDEV_TARGET_ARCH="arm64"
     WBDEV_TARGET_RELEASE="trixie"
     QEMU_ARCH="aarch64"
+    export QEMU_CPU="cortex-a53"
     ROOTFS_PKG_CONFIG_PATH="/rootfs/trixie-arm64/usr/lib/aarch64-linux-gnu/pkgconfig"
     ;;
 trixie-host|trixie-amd64|current-host|current-amd64)


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
после апдейта qemu в трикси с 5 до 10 сборка rootfs для arm64 стала очень медленной (в 5-6 раз медленнее), таблетка найдена тут https://github.com/armbian/build/commit/3006a0826c68333b030fa675e6858bdb4d05ed4d

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**


