### PR TITLE
Switch to ftp.ru.debian.org mirror

### DIFF
--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -7,7 +7,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV PIP_BREAK_SYSTEM_PACKAGES 1
 
 # ca-certificates should be installed before moving to debian-mirror.wirenboard.com
-RUN sed -i 's#deb.debian.org#mirror.docker.ru#' /etc/apt/sources.list.d/debian.sources && \
+RUN sed -i 's#deb.debian.org#ftp.ru.debian.org#' /etc/apt/sources.list.d/debian.sources && \
     apt update && apt install -y curl wget gnupg && \
     echo 'APT::Key::gpgvcommand "/usr/bin/gpgv";' > /etc/apt/apt.conf.d/99use-gpgv && \
     curl -fsSL https://deb.wirenboard.com/wirenboard-keyring.gpg > \
@@ -19,7 +19,7 @@ RUN sed -i 's#deb.debian.org#mirror.docker.ru#' /etc/apt/sources.list.d/debian.s
     curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor -o /usr/share/keyrings/apt.llvm.org.gpg && \
     echo "deb [arch=amd64 signed-by=/usr/share/keyrings/apt.llvm.org.gpg] http://apt.llvm.org/trixie/ llvm-toolchain-trixie-22 main" > \
        /etc/apt/sources.list.d/llvm-trixie-22.list && \
-    sed -i 's#mirror.docker.ru#debian-mirror.wirenboard.com#' /etc/apt/sources.list.d/debian.sources && \
+    sed -i 's#ftp.ru.debian.org#debian-mirror.wirenboard.com#' /etc/apt/sources.list.d/debian.sources && \
     apt update && \
     apt install -y --force-yes git gpg debootstrap proot build-essential pkg-config debhelper \
        nodejs bash-completion nano gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu sudo locales \


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
mirror.docker.ru стало недоступно с дженкинса (хотя само по себе живо):
```
Failed to fetch http://mirror.docker.ru/debian/dists/trixie/InRelease  Unable to connect to mirror.docker.ru:80:
```

___________________________________
**Что поменялось для пользователей:**


___________________________________
**Как проверял/а:**


