### PR TITLE
Add persistent Go build and module cache to sbuild

### DIFF
--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -72,6 +72,7 @@ COPY chr /usr/local/bin/
 RUN chmod +x /root/*.sh /usr/local/bin/chr
 
 RUN mkdir -p /var/cache/ccache && chmod 777 /var/cache/ccache
+RUN mkdir -p /var/cache/go && chmod 777 /var/cache/go
 COPY schroot/fstab /etc/schroot/sbuild/fstab
 COPY schroot/copyfiles /etc/schroot/sbuild/copyfiles
 COPY schroot/ccache-setup /usr/local/bin/ccache-setup

--- a/devenv/build.sh
+++ b/devenv/build.sh
@@ -111,6 +111,11 @@ EOF
 	#output everyting on screen instead of file
 	echo "\$nolog = 1;" >> /etc/sbuild/sbuild.conf
 
+	# persist Go build and module cache across builds (bind-mounted from /var/cache/go, see schroot/fstab).
+	# append keys rather than reassign $build_environment, to keep sbuild's own PATH/LD_LIBRARY_PATH defaults.
+	echo "\$build_environment->{'GOCACHE'} = '/var/cache/go/build';" >> /etc/sbuild/sbuild.conf
+	echo "\$build_environment->{'GOMODCACHE'} = '/var/cache/go/mod';" >> /etc/sbuild/sbuild.conf
+
 	# enable ccache wrapper
 	echo "command-prefix=/usr/local/bin/ccache-setup" >> "${SCHROOT_CONF}"
 

--- a/devenv/schroot/fstab
+++ b/devenv/schroot/fstab
@@ -11,3 +11,4 @@ tmpfs           /dev/shm        tmpfs   defaults        0       0
 # space on an LVM snapshot of the chroot itself.
 /var/lib/sbuild/build  /build   none    rw,bind         0       0
 /var/cache/ccache      /var/cache/ccache  none    rw,bind         0       0
+/var/cache/go          /var/cache/go      none    rw,bind         0       0

--- a/devenv/wbdev_second_half.sh
+++ b/devenv/wbdev_second_half.sh
@@ -60,6 +60,16 @@ else
     fi
 fi
 
+if [[ -n "$DEV_GOCACHE_VOLUME" ]]; then
+    export WBDEV_GOCACHE_DIR=${WBDEV_GOCACHE_DIR:-/var/cache/go}
+    VOLUMES="$VOLUMES -v $DEV_GOCACHE_VOLUME:$WBDEV_GOCACHE_DIR"
+else
+    if [[ -n "$WBDEV_GOCACHE_DIR" ]]; then
+        echo "WBDEV_GOCACHE_DIR is set but DEV_GOCACHE_VOLUME is not"
+        exit 1
+    fi
+fi
+
 ENV_CMDLINE=""
 for var in $(env | grep -o "WBDEV_[^=]*"); do
     ENV_CMDLINE="$ENV_CMDLINE -e $var"


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

Ускоряем CI-сборку Go-пакетов (wb-rules и др.). Сейчас `go build` каждый прогон
пересобирает stdlib и все зависимости с нуля: sbuild работает с
`HOME=/sbuild-nonexistent`, поэтому `GOCACHE`/`GOMODCACHE` лежат внутри одноразовой
schroot-сессии и теряются, плюс модули качаются заново каждый билд.

Сохраняем их ровно так же, как уже сделано для ccache: docker-том монтируется в
devenv-контейнер в `/var/cache/go`, биндится в schroot, а `GOCACHE`/`GOMODCACHE`
указывают туда через sbuild `$build_environment` (он не подпадает под
`environment_filter`, поэтому переживает `dpkg-buildpackage --sanitize-env`).

Тикет: INF-655. Парный том создаётся ролью `wb_buildagent` в репо `infra`.

___________________________________
**Что поменялось для пользователей:**

Для сборок в devenv/CI: Go-кэш переиспользуется между прогонами → компиляция
быстрее (прогон тестов и apt-фазу это не ускоряет). Кэш общий для всех Go-пакетов
и веток на агенте — это безопасно: кэш Go контентно-адресуемый и в ключ входят
`GOARCH/GOARM/toolchain`, так что параллельные armhf/arm64 не мешают друг другу.

Без подключённого тома `/var/cache/go` — пустая эфемерная папка в контейнере
(как ccache без тома), поведение прежнее. Локальный `wbdev` без `DEV_GOCACHE_VOLUME`
не затрагивается.

___________________________________
**Как проверял/а:**

- `bash -n` на `wbdev_second_half.sh` и `build.sh` — синтаксис ок.
- Диффы — точный зеркальный аналог существующей обвязки ccache (том → контейнер →
  fstab-бинд → chroot).

Требует проверки после пересборки образа `contactless/devenv:latest` (локально
devenv не гонял):
- что sbuild корректно парсит добавленную строку `$build_environment` в
  `/etc/sbuild/sbuild.conf`;
- реальный выигрыш по времени — замером до/после на сборке wb-rules с
  подключённым томом.

Порядок раскатки: этот PR → пересборка/публикация `contactless/devenv:latest` →
merge `infra` INF-655 → прогон плейбука на билд-агенте.