### PR TITLE
Fix rootfs build on macOS

### DIFF
--- a/boards/init_board.sh
+++ b/boards/init_board.sh
@@ -20,5 +20,39 @@ export BOARD_PACKAGES=()
 	exit 1
 }
 
-ROOTFS=${ROOTFS:-${WORK_DIR}/rootfs_wb${BOARD}}
+ROOTFS_DEFAULT="${WORK_DIR}/rootfs_wb${BOARD}"
+ROOTFS=${ROOTFS:-$ROOTFS_DEFAULT}
 IMAGES_DIR=${IMAGES_DIR:-${WORK_DIR}/images}
+
+# The rootfs must be built on a CASE-SENSITIVE filesystem. debootstrap unpacks
+# packages (e.g. libpam) that ship files differing only in case (pam.7.gz and
+# PAM.7.gz); on a case-insensitive filesystem these collide and extraction fails
+# with "tar: ... Cannot create symlink to 'PAM.7.gz': File exists". This bites
+# when WORK_DIR lives on a macOS bind mount (APFS is case-insensitive by
+# default), which is why local builds break on macOS but not on Linux.
+#
+# When the default output location is case-insensitive, build the rootfs on the
+# container's own (case-sensitive) filesystem instead; the images and the
+# base-rootfs tarball cache stay in WORK_DIR. Both create_rootfs.sh and
+# create_images.sh source this file, so they agree on the relocated path.
+# Set ROOTFS (or WB_CASEFS_ROOTFS_DIR) explicitly to override.
+dir_is_case_insensitive() {
+	local dir="$1" probe ret
+	mkdir -p "$dir" 2>/dev/null || return 1
+	probe="${dir}/.wb-casecheck.$$"
+	rm -f "${probe}a" "${probe}A" 2>/dev/null
+	: > "${probe}a" 2>/dev/null || return 1
+	ret=1
+	if [ -e "${probe}A" ]; then ret=0; fi
+	rm -f "${probe}a" "${probe}A" 2>/dev/null
+	return $ret
+}
+
+if [ "$ROOTFS" = "$ROOTFS_DEFAULT" ] && dir_is_case_insensitive "$WORK_DIR"; then
+	ROOTFS="${WB_CASEFS_ROOTFS_DIR:-/var/tmp/wb-rootfs}/rootfs_wb${BOARD}"
+	mkdir -p "$(dirname "$ROOTFS")"
+	echo "NOTE: $WORK_DIR is on a case-insensitive filesystem (e.g. macOS)." >&2
+	echo "      Building rootfs at $ROOTFS instead so debootstrap does not fail" >&2
+	echo "      on case-only-differing files; images/cache stay in $WORK_DIR." >&2
+	echo "      Set ROOTFS to override." >&2
+fi


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
на macOS сборка рутфс не работала из-за case-insensitive APFS:
```sh
$ ./wbdev root bash -c "WB_RELEASE=testing DEBIAN_RELEASE=trixie ./rootfs/create_rootfs.sh 8x"
<...>
I: Extracting libpam-runtime...
E: Tried to extract package, but tar failed. Exit...
Error in ./rootfs/create_rootfs.sh:235. 'debootstrap --foreign --verbose --arch $ARCH --variant=minbase --include=ca-certificates,gpgv ${DEBIAN_RELEASE} ${OUTPUT} ${REPO}' exited with status 0
Exiting with status 1
```

___________________________________
**Что поменялось для пользователей:**
возможность собрать рутфс на маке, на linux ничего не поменялось

___________________________________
**Как проверял/а:**
локально

