### PR TITLE
devenv: enable trixie-backports

### DIFF
--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -8,6 +8,7 @@ ENV PIP_BREAK_SYSTEM_PACKAGES 1
 
 # ca-certificates should be installed before moving to debian-mirror.wirenboard.com
 RUN sed -i 's#deb.debian.org#ftp.ru.debian.org#' /etc/apt/sources.list.d/debian.sources && \
+    sed -i 's#^Suites: trixie trixie-updates$#& trixie-backports#' /etc/apt/sources.list.d/debian.sources && \
     apt update && apt install -y curl wget gnupg && \
     echo 'APT::Key::gpgvcommand "/usr/bin/gpgv";' > /etc/apt/apt.conf.d/99use-gpgv && \
     curl -fsSL https://deb.wirenboard.com/wirenboard-keyring.gpg > \
@@ -24,11 +25,11 @@ RUN sed -i 's#deb.debian.org#ftp.ru.debian.org#' /etc/apt/sources.list.d/debian.
     apt install -y --force-yes git gpg debootstrap build-essential pkg-config debhelper \
        nodejs bash-completion nano gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu sudo locales \
        devscripts python3-virtualenv python3-pip equivs qemu-user-static binfmt-support \
-       libmosquittopp-dev libmosquitto-dev pkg-config gcc g++ libmodbus-dev debian-archive-keyring \
-       libcurl4-gnutls-dev libsqlite3-dev libjsoncpp-dev sbuild kpartx zip device-tree-compiler \
-       valgrind libgtest-dev google-mock cmake config-package-dev libssl-dev bc lzip lzop \
-       python3-netaddr python3-pyparsing libusb-dev libusb-1.0-0-dev jq \
-       python3-smbus python3-setuptools liblog4cpp5-dev libpng-dev bison flex kmod dh-python \
+       debian-archive-keyring \
+       sbuild kpartx zip device-tree-compiler \
+       valgrind cmake bc lzip lzop \
+       python3-netaddr python3-pyparsing jq \
+       python3-smbus python3-setuptools bison flex kmod dh-python \
        clang-format-22 clang-tidy-22 lintian ccache \
     # for image building \
     fdisk u-boot-tools-wb fit-aligner cpio \

--- a/devenv/build.sh
+++ b/devenv/build.sh
@@ -21,10 +21,37 @@ do_build_sbuild_env() {
 
 	shift
 	local ADD_PACKAGES=("$@")
+	local INCLUDE_PACKAGES=(
+	    crossbuild-essential-arm64
+	    crossbuild-essential-armhf
+	    build-essential
+	    libarchive-zip-perl
+	    libtimedate-perl
+	    pkg-config
+	    libfile-stripnondeterminism-perl
+	    gettext
+	    intltool-debian
+	    po-debconf
+	    dh-autoreconf
+	    dh-strip-nondeterminism
+	    debhelper
+	    cmake
+	    git
+	    ca-certificates
+	    ccache
+	    gpgv
+	    apt-utils
+	    perl-openssl-defaults
+	    lintian
+	)
 
 	REPO="http://debian-mirror.wirenboard.com/debian"
 
-	sbuild-createchroot --no-deb-src --include="crossbuild-essential-arm64 crossbuild-essential-armhf build-essential libarchive-zip-perl libtimedate-perl pkg-config libfile-stripnondeterminism-perl gettext intltool-debian po-debconf dh-autoreconf dh-strip-nondeterminism debhelper libgtest-dev cmake git ca-certificates ccache gpgv apt-utils perl-openssl-defaults lintian" ${RELEASE} ${ROOTFS} ${REPO}
+	sbuild-createchroot \
+	    --no-deb-src \
+	    --extra-repository="deb $REPO trixie-backports main" \
+	    --include="$(IFS=,; echo "${INCLUDE_PACKAGES[*]}")" \
+	    ${RELEASE} ${ROOTFS} ${REPO}
 	SCHROOT_CONF="$(find /etc/schroot/chroot.d/ -name "${CHROOT_NAME}*" -type f | head -n1)"
 	touch /etc/ccache.conf  # make schroot's copyfiles happy
 
@@ -55,9 +82,15 @@ EOF
 	# prevent e2fsprogs packages from being installed from wb repo, it messes up with host versions.
 	# it is only needed for actual hardware anyway
 	cat <<EOF >${ROOTFS}/etc/apt/preferences.d/000libext2fs
-Package: src:e2fsprogs:any
+Package: src:e2fsprogs
 Pin: release o=wirenboard
 Pin-Priority: -1
+EOF
+
+	cat <<EOF >${ROOTFS}/etc/apt/preferences.d/001backports
+Package: src:curl src:ngtcp2 src:nghttp3
+Pin: release n=trixie-backports
+Pin-Priority: 990
 EOF
 
 	schroot -c ${CHROOT_NAME} --directory=/ -- apt-get update

--- a/devenv/build.sh
+++ b/devenv/build.sh
@@ -82,13 +82,13 @@ EOF
 	# prevent e2fsprogs packages from being installed from wb repo, it messes up with host versions.
 	# it is only needed for actual hardware anyway
 	cat <<EOF >${ROOTFS}/etc/apt/preferences.d/000libext2fs
-Package: src:e2fsprogs
+Package: src:e2fsprogs:any
 Pin: release o=wirenboard
 Pin-Priority: -1
 EOF
 
 	cat <<EOF >${ROOTFS}/etc/apt/preferences.d/001backports
-Package: src:curl src:ngtcp2 src:nghttp3
+Package: src:curl:any src:ngtcp2:any src:nghttp3:any
 Pin: release n=trixie-backports
 Pin-Priority: 990
 EOF

--- a/devenv/prep.sh
+++ b/devenv/prep.sh
@@ -10,13 +10,15 @@ prepare_chroot
 services_disable
 
 /bin/echo -e 'APT::Get::Assume-Yes "true";\nAPT::Get::force-yes "true";' >$ROOTFS/etc/apt/apt.conf.d/90forceyes
+# we don't need the "Translations" files, so we're just wasting time and space by downloading them
+/bin/echo -e 'Acquire::Languages "none";' > $ROOTFS/etc/apt/apt.conf.d/91no-languages
+
 chr apt-get update
 
 pkgs=(devscripts equivs build-essential \
     pkg-config bash-completion \
-    libgtest-dev google-mock cmake \
-    cdbs autoconf automake libtool \
-    git git-man gcc g++ ccache
+    cmake cdbs autoconf automake libtool \
+    git git-man ccache
 )
 
 chr_apt_install "${pkgs[@]}"

--- a/rootfs/create_rootfs.sh
+++ b/rootfs/create_rootfs.sh
@@ -297,7 +297,7 @@ EOM
     echo "Pin: release o=wirenboard, a=$WB_RELEASE" >> ${APT_PIN_TMP_FNAME}
     echo "Pin-Priority: 990" >> ${APT_PIN_TMP_FNAME}
     if [[ "$DEBIAN_RELEASE" = "trixie" ]]; then
-        echo "Package: src:curl src:ngtcp2 src:nghttp3" >> ${APT_PIN_TMP_FNAME}
+        echo "Package: src:curl:any src:ngtcp2:any src:nghttp3:any" >> ${APT_PIN_TMP_FNAME}
         echo "Pin: release n=${DEBIAN_RELEASE}-backports" >> ${APT_PIN_TMP_FNAME}
         echo "Pin-Priority: 990" >> ${APT_PIN_TMP_FNAME}
     fi

--- a/rootfs/create_rootfs.sh
+++ b/rootfs/create_rootfs.sh
@@ -297,7 +297,7 @@ EOM
     echo "Pin: release o=wirenboard, a=$WB_RELEASE" >> ${APT_PIN_TMP_FNAME}
     echo "Pin-Priority: 990" >> ${APT_PIN_TMP_FNAME}
     if [[ "$DEBIAN_RELEASE" = "trixie" ]]; then
-        echo "Package: curl libcurl4t64 libngtcp2-16 libnghttp3-9" >> ${APT_PIN_TMP_FNAME}
+        echo "Package: src:curl src:ngtcp2 src:nghttp3" >> ${APT_PIN_TMP_FNAME}
         echo "Pin: release n=${DEBIAN_RELEASE}-backports" >> ${APT_PIN_TMP_FNAME}
         echo "Pin-Priority: 990" >> ${APT_PIN_TMP_FNAME}
     fi


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
* включает trixie-backports для `wbdev root` и sbuild chroot, чтобы при сборке использовать те же пакеты что и на контроллере (где backports включен для curl и зависимостей)

Минорные:
* `*-dev` зависимости в корень devenv ставить не надо, все сборки происходят в sbuild chroot
* gcc и g++ явно можно не указывать, ставятся как build-essential
* добавлен `Acquire::Languages "none";` чтобы не загружать каждый раз Translations, которые не нужны для сборок

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**


