### PR TITLE
devenv: add apt-utils and lintian to sbuild chroot

### DIFF
--- a/devenv/build.sh
+++ b/devenv/build.sh
@@ -24,7 +24,7 @@ do_build_sbuild_env() {
 
 	REPO="http://debian-mirror.wirenboard.com/debian"
 
-	sbuild-createchroot --include="crossbuild-essential-arm64 crossbuild-essential-armhf build-essential libarchive-zip-perl libtimedate-perl pkg-config libfile-stripnondeterminism-perl gettext intltool-debian po-debconf dh-autoreconf dh-strip-nondeterminism debhelper libgtest-dev cmake git ca-certificates ccache gpgv" ${RELEASE} ${ROOTFS} ${REPO}
+	sbuild-createchroot --no-deb-src --include="crossbuild-essential-arm64 crossbuild-essential-armhf build-essential libarchive-zip-perl libtimedate-perl pkg-config libfile-stripnondeterminism-perl gettext intltool-debian po-debconf dh-autoreconf dh-strip-nondeterminism debhelper libgtest-dev cmake git ca-certificates ccache gpgv apt-utils perl-openssl-defaults lintian" ${RELEASE} ${ROOTFS} ${REPO}
 	SCHROOT_CONF="$(find /etc/schroot/chroot.d/ -name "${CHROOT_NAME}*" -type f | head -n1)"
 	touch /etc/ccache.conf  # make schroot's copyfiles happy
 


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Для каждой сборки deb пакета нужны apt-utils и lintian, сейчас они каждый раз скачиваются, при том что lintian тянет за собой много зависимостей => предустановить в sbuild chroot

___________________________________
**Что поменялось для пользователей:**
ускорение сборки почти в 2 раза на примере сириала:
<img width="212" height="453" alt="Screen Shot 2026-07-31 at 15 44 43" src="https://github.com/user-attachments/assets/9d4d0ed5-d321-4565-9a82-0f7c7dea41ee" />

общее количество загрузок уменьшилось c 678 до 267:
```sh
git jl | grep "debian-mirror" | grep Get | wc -l
     678
```
```sh
git jl | grep "debian-mirror" | grep Get | wc -l
     267
```

___________________________________
**Как проверял/а:**
на дженкинсе

