### PR TITLE
devenv: add target and sysroot to compiledb

### DIFF
--- a/devenv/Dockerfile
+++ b/devenv/Dockerfile
@@ -27,7 +27,7 @@ RUN sed -i 's#deb.debian.org#ftp.ru.debian.org#' /etc/apt/sources.list.d/debian.
        libmosquittopp-dev libmosquitto-dev pkg-config gcc g++ libmodbus-dev debian-archive-keyring \
        libcurl4-gnutls-dev libsqlite3-dev libjsoncpp-dev sbuild kpartx zip device-tree-compiler \
        valgrind libgtest-dev google-mock cmake config-package-dev libssl-dev bc lzip lzop \
-       python3-netaddr python3-pyparsing libusb-dev libusb-1.0-0-dev jq \
+       python3-netaddr python3-pyparsing libusb-dev libusb-1.0-0-dev jq moreutils \
        python3-smbus python3-setuptools liblog4cpp5-dev libpng-dev bison flex kmod dh-python \
        clang-format-22 clang-tidy-22 lintian ccache \
     # for image building \

--- a/devenv/entrypoint.sh
+++ b/devenv/entrypoint.sh
@@ -208,6 +208,28 @@ die() {
     exit 1
 }
 
+target_triple() {
+    case "$WBDEV_TARGET_ARCH" in
+        armhf) echo "arm-linux-gnueabihf" ;;
+        arm64) echo "aarch64-linux-gnu" ;;
+    esac
+}
+
+add_target_to_compiledb() {
+    local db="compile_commands.json"
+    local triple
+    triple=$(target_triple)
+
+    [ -n "$triple" ] || return 0
+    [ -f "$db" ] || return 0
+
+    echo "Adding --target=$triple --sysroot=$ROOTFS to $db"
+    jq --arg target "--target=$triple" --arg sysroot "--sysroot=$ROOTFS" \
+       'map(if has("arguments") then .arguments += [$target, $sysroot]
+            else .command += " " + $target + " " + $sysroot end)' \
+       "$db" | sponge "$db"
+}
+
 wb_repo_path() {
     PLATFORM=$1
     PREFIX=${2:-$WBDEV_TARGET_REPO_PREFIX}
@@ -437,6 +459,7 @@ case "$cmd" in
         elif [ -f Makefile ]; then
             chu make -Bnwk | compiledb -o compile_commands.json
         fi
+        add_target_to_compiledb
         $shell_cmd "$@"
         ;;
     cdeb)


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
Суть в том что compiledb собираем в chroot под таргет, а clang-tidy использует его в контейнере, не в chroot (запускать clang-tidy в chroot было бы сильно накладно из-за qemu). Из-за этого приходилось передавать через CLANG_TIDY_EXTRA_ARG пути к хидерам в рутфс. После https://github.com/wirenboard/wirenboard/pull/277 понадобились дополнительные пути, поэтому чтобы уйти от этого сразу выставим --sysroot и --target в compiledb, таким образом не надо будет передавать пути к хидерам через CLANG_TIDY_EXTRA_ARG.

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
на сборке сириала

