### PR TITLE
Bump go to 1.26

### DIFF
--- a/devenv/build.sh
+++ b/devenv/build.sh
@@ -78,8 +78,7 @@ EOF
 		schroot -c ${CHROOT_NAME} --directory=/ -- apt-get -y install \
 			libglib2.0-0t64 \
 			libcares2:arm64 libcares2:armhf \
-			golang-1.24-go \
-			binutils-gold-aarch64-linux-gnu # https://github.com/golang/go/issues/22040
+			golang-1.26-go # from trixie-backports
 	fi
 
 	#virtualization support packages


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**
переводим сборку на 1.26:
* https://github.com/wirenboard/wb-rules/pull/218
* https://github.com/wirenboard/wb-mqtt-confed/pull/84

gold линкер больше не нужен для arm64

___________________________________
**Что поменялось для пользователей:**
ничего

___________________________________
**Как проверял/а:**
сборка wb-rules

