### PR TITLE
docs: fix dead link to VSCode configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ wget -O /path/to/your/wbdev-script https://raw.githubusercontent.com/wirenboard/
 VSCode building and debugging 
 =============================
 
-There are VSCode config files in [vscode](vscode) folder. These files can be used to build and debug Wiren Board software. Take some attention on `includePath` settings in `c_cpp_properties.json` and `command` settings in debug tasks in *tasks.json* because they contain sensitive settings for your environment. In `Debug build and copy to wb7` and `Build and copy to wb7` tasks you should insert your controller's IP.
+There are VSCode config files in the [codestyle](https://github.com/wirenboard/codestyle/tree/master/cpp/vscode) repository, `cpp/vscode` folder. These files can be used to build and debug Wiren Board software. Take some attention on `includePath` settings in `c_cpp_properties.json` and `command` settings in debug tasks in *tasks.json* because they contain sensitive settings for your environment. In `Debug build and copy to wb7` and `Build and copy to wb7` tasks you should insert your controller's IP.
 
 For build and run cpp tests you need to install `qemu` and `binfmt` packages on your host.
 ```


### PR DESCRIPTION
___________________________________
**Что происходит; кому и зачем нужно:**

В README раздел «VSCode building and debugging» ссылается на папку `vscode`,
удалённую в #255 (05.11.2025) — ссылка отдаёт 404 девять месяцев. Конфиги
переехали в `wirenboard/codestyle`, каталог `cpp/vscode`, поправляю ссылку.

Всплыло на портале поддержки: клиент двое суток настраивал отладку по C
на контроллере (support.wirenboard.com/t/41254) и в итоге дошёл ровно до
`tasks.json` и `launch.json` — тех самых файлов, которые README обещает.

BTW, конфиги для Go (`vscode/go/.devcontainer`,  `vscode/go/wb-rules/.vscode/tasks.json`) 
в codestyle я не нашёл?
___________________________________
**Что поменялось для пользователей:**

Теперь файлы можно будет найти по ссылке
___________________________________
**Как проверял/а:**
Щелкнул по ссылкее и попал в нужное место

